### PR TITLE
Refactor MoveGenerator

### DIFF
--- a/movegen/src/attacks_to.rs
+++ b/movegen/src/attacks_to.rs
@@ -1,0 +1,206 @@
+use crate::bishop::Bishop;
+use crate::king::King;
+use crate::knight::Knight;
+use crate::pawn::Pawn;
+use crate::queen::Queen;
+use crate::rook::Rook;
+
+use crate::bitboard::Bitboard;
+use crate::piece;
+use crate::piece_targets::PieceTargets;
+use crate::position::Position;
+use crate::side::Side;
+use crate::square::Square;
+
+pub struct AttacksTo<'a> {
+    pub pos: &'a Position,
+    pub target: Square,
+    pub all_attack_targets: Bitboard,
+    pub attack_origins: Bitboard,
+    pub each_slider_attack: Vec<PieceTargets>,
+    pub xrays_to_target: Bitboard,
+    pub each_xray: Vec<PieceTargets>,
+}
+
+impl AttacksTo<'_> {
+    pub fn new(pos: &Position, target: Square, attacking_side: Side) -> AttacksTo {
+        let (all_pawn_targets, pawn_origins) =
+            Self::pawn_attacks_towards_target(pos, target, attacking_side);
+        let (all_knight_targets, knight_origins) = Self::attacks_towards_target(
+            pos,
+            piece::Type::Knight,
+            &Knight::targets,
+            target,
+            attacking_side,
+        );
+        let (
+            all_bishop_targets,
+            bishop_origins,
+            mut each_bishop_attack,
+            bishop_xrays,
+            mut each_bishop_xray,
+        ) = Self::slider_attacks_towards_target(
+            pos,
+            piece::Type::Bishop,
+            &Bishop::targets,
+            target,
+            attacking_side,
+        );
+        let (all_rook_targets, rook_origins, mut each_rook_attack, rook_xrays, mut each_rook_xray) =
+            Self::slider_attacks_towards_target(
+                pos,
+                piece::Type::Rook,
+                &Rook::targets,
+                target,
+                attacking_side,
+            );
+        let (
+            all_queen_targets,
+            queen_origins,
+            mut each_queen_attack,
+            queen_xrays,
+            mut each_queen_xray,
+        ) = Self::slider_attacks_towards_target(
+            pos,
+            piece::Type::Queen,
+            &Queen::targets,
+            target,
+            attacking_side,
+        );
+        let (all_king_targets, king_origins) = Self::attacks_towards_target(
+            pos,
+            piece::Type::King,
+            &King::targets,
+            target,
+            attacking_side,
+        );
+
+        let mut each_slider_attack = Vec::new();
+        each_slider_attack.append(&mut each_bishop_attack);
+        each_slider_attack.append(&mut each_rook_attack);
+        each_slider_attack.append(&mut each_queen_attack);
+
+        let all_attack_targets = all_pawn_targets
+            | all_knight_targets
+            | all_bishop_targets
+            | all_rook_targets
+            | all_queen_targets
+            | all_king_targets;
+        let attack_origins = pawn_origins
+            | knight_origins
+            | bishop_origins
+            | rook_origins
+            | queen_origins
+            | king_origins;
+
+        let xrays_to_target = bishop_xrays | rook_xrays | queen_xrays;
+        let mut each_xray = Vec::new();
+        each_xray.append(&mut each_bishop_xray);
+        each_xray.append(&mut each_rook_xray);
+        each_xray.append(&mut each_queen_xray);
+
+        AttacksTo {
+            pos,
+            target,
+            all_attack_targets,
+            attack_origins,
+            each_slider_attack,
+            xrays_to_target,
+            each_xray,
+        }
+    }
+
+    fn pawn_attacks_towards_target(
+        pos: &Position,
+        target: Square,
+        attacking_side: Side,
+    ) -> (Bitboard, Bitboard) {
+        let target_bb = Bitboard::from_square(target);
+        let pawns = pos.piece_occupancy(attacking_side, piece::Type::Pawn);
+
+        let east_targets = Pawn::east_attack_targets(pawns, attacking_side);
+        let east_origins = Pawn::east_attack_origins(east_targets & target_bb, attacking_side);
+        let west_targets = Pawn::west_attack_targets(pawns, attacking_side);
+        let west_origins = Pawn::west_attack_origins(west_targets & target_bb, attacking_side);
+
+        let all_attack_targets = east_targets | west_targets;
+        let attack_origins = east_origins | west_origins;
+
+        (all_attack_targets, attack_origins)
+    }
+
+    fn attacks_towards_target(
+        pos: &Position,
+        piece_type: piece::Type,
+        piece_targets: &impl Fn(Square) -> Bitboard,
+        target: Square,
+        attacking_side: Side,
+    ) -> (Bitboard, Bitboard) {
+        let target_bb = Bitboard::from_square(target);
+        let mut pieces = pos.piece_occupancy(attacking_side, piece_type);
+        let mut all_attack_targets = Bitboard::EMPTY;
+        let mut attack_origins = Bitboard::EMPTY;
+        while pieces != Bitboard::EMPTY {
+            let attack_origin = pieces.square_scan_forward_reset();
+            let attack_targets = piece_targets(attack_origin);
+            all_attack_targets |= attack_targets;
+            if attack_targets & target_bb != Bitboard::EMPTY {
+                attack_origins |= Bitboard::from_square(attack_origin);
+            }
+        }
+
+        (all_attack_targets, attack_origins)
+    }
+
+    fn slider_attacks_towards_target(
+        pos: &Position,
+        piece_type: piece::Type,
+        piece_targets: &impl Fn(Square, Bitboard) -> Bitboard,
+        target: Square,
+        attacking_side: Side,
+    ) -> (
+        Bitboard,
+        Bitboard,
+        Vec<PieceTargets>,
+        Bitboard,
+        Vec<PieceTargets>,
+    ) {
+        let target_bb = Bitboard::from_square(target);
+        let mut pieces = pos.piece_occupancy(attacking_side, piece_type);
+        let mut all_attack_targets = Bitboard::EMPTY;
+        let mut attack_origins = Bitboard::EMPTY;
+        let mut each_slider_attack = Vec::new();
+        let mut xrays_to_target = Bitboard::EMPTY;
+        let mut each_xray = Vec::new();
+        while pieces != Bitboard::EMPTY {
+            let attack_origin = pieces.square_scan_forward_reset();
+            let attack_targets = piece_targets(attack_origin, pos.occupancy());
+            all_attack_targets |= attack_targets;
+            if attack_targets & target_bb != Bitboard::EMPTY {
+                attack_origins |= Bitboard::from_square(attack_origin);
+                each_slider_attack.push(PieceTargets::new(
+                    piece::Piece::new(attacking_side, piece_type),
+                    attack_origin,
+                    attack_targets,
+                ));
+            }
+            let xray_targets = piece_targets(attack_origin, Bitboard::EMPTY);
+            if xray_targets & target_bb != Bitboard::EMPTY {
+                xrays_to_target |= xray_targets;
+                each_xray.push(PieceTargets::new(
+                    piece::Piece::new(attacking_side, piece_type),
+                    attack_origin,
+                    xray_targets,
+                ));
+            }
+        }
+
+        (
+            all_attack_targets,
+            attack_origins,
+            each_slider_attack,
+            xrays_to_target,
+            each_xray,
+        )
+    }
+}

--- a/movegen/src/lib.rs
+++ b/movegen/src/lib.rs
@@ -19,7 +19,9 @@ pub mod square;
 pub mod transposition_table;
 pub mod zobrist;
 
+mod attacks_to;
 mod direction;
 mod file;
+mod piece_targets;
 mod rank;
 mod ray;

--- a/movegen/src/move_generator/king_in_check_generator.rs
+++ b/movegen/src/move_generator/king_in_check_generator.rs
@@ -1,0 +1,118 @@
+use crate::move_generator::move_generator_template::MoveGeneratorTemplate;
+
+use crate::attacks_to::AttacksTo;
+use crate::bitboard::Bitboard;
+use crate::pawn::Pawn;
+use crate::r#move::MoveList;
+use crate::square::Square;
+
+// In check, the only legal moves are:
+// - Move the king to safety
+// - Capture the attacker
+// - Block the attack (only if the attacker is a sliding piece)
+// In double check, only king moves are legal
+pub struct KingInCheckGenerator;
+
+impl MoveGeneratorTemplate for KingInCheckGenerator {
+    fn non_capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        debug_assert_eq!(1, attacks_to_king.attack_origins.pop_count());
+        // Blocking is only possible, if the king is attacked by a sliding piece.
+        // Otherwise, the king must move or the attacker must be captured.
+        match attacks_to_king.each_slider_attack.first() {
+            Some(slider) => targets & slider.targets() & !attacks_to_king.pos.occupancy(),
+            None => Bitboard::EMPTY,
+        }
+    }
+
+    fn capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        debug_assert_eq!(1, attacks_to_king.attack_origins.pop_count());
+        targets & attacks_to_king.attack_origins
+    }
+
+    fn pawn_capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        targets & (attacks_to_king.attack_origins | attacks_to_king.pos.en_passant_square())
+    }
+
+    fn is_legal_non_capture(attacks_to_king: &AttacksTo, origin: Square, target: Square) -> bool {
+        let pos = attacks_to_king.pos;
+        let origin_bb = Bitboard::from_square(origin);
+        let target_bb = Bitboard::from_square(target);
+        let occupancy_after_move = pos.occupancy() & !origin_bb | target_bb;
+        let own_king = Bitboard::from_square(attacks_to_king.target);
+        let king_in_check_after_move = attacks_to_king
+            .each_xray
+            .iter()
+            .map(|x| Self::sliding_piece_targets(x, occupancy_after_move))
+            .any(|x| x & own_king != Bitboard::EMPTY);
+        !king_in_check_after_move
+    }
+
+    fn is_legal_capture(attacks_to_king: &AttacksTo, origin: Square, target: Square) -> bool {
+        let pos = attacks_to_king.pos;
+        let origin_bb = Bitboard::from_square(origin);
+        let occupancy_after_move = pos.occupancy() & !origin_bb;
+        let own_king = Bitboard::from_square(attacks_to_king.target);
+        let king_in_check_after_move = attacks_to_king
+            .each_xray
+            .iter()
+            .filter(|x| (x.origin() != target) && (x.targets() & origin_bb != Bitboard::EMPTY))
+            .map(|x| Self::sliding_piece_targets(x, occupancy_after_move))
+            .any(|x| x & own_king != Bitboard::EMPTY);
+        !king_in_check_after_move
+    }
+
+    fn is_legal_en_passant_capture(
+        attacks_to_king: &AttacksTo,
+        origin: Square,
+        target: Square,
+    ) -> bool {
+        let pos = attacks_to_king.pos;
+        let origin_bb = Bitboard::from_square(origin);
+        let target_bb = Bitboard::from_square(target);
+        let captured_square = Pawn::push_origin(target, pos.side_to_move());
+        let captured_bb = Bitboard::from_square(captured_square);
+        if captured_bb == attacks_to_king.attack_origins {
+            // Our king is attacked by the pawn that just moved. In this case we must check if our
+            // own pawn is pinned to the king. The opponent's pawn is not blocking a sliding attack
+            // (otherwise our king would already have been attacked before the opponent's move
+            // which would be an illegal position).
+            let own_king = Bitboard::from_square(attacks_to_king.target);
+            let occupancy_after_move = pos.occupancy() & !origin_bb & !captured_bb | target_bb;
+            let king_in_check_after_move = attacks_to_king
+                .each_xray
+                .iter()
+                .filter(|x| x.targets() & origin_bb != Bitboard::EMPTY)
+                .map(|x| Self::sliding_piece_targets(x, occupancy_after_move))
+                .any(|x| x & own_king != Bitboard::EMPTY);
+            !king_in_check_after_move
+        } else {
+            // Our king is attacked by a sliding piece (after a discovered attack). Capturing en
+            // passant is not possible because the attacker will not be blocked.
+            false
+        }
+    }
+
+    fn is_legal_king_move(attacks_to_king: &AttacksTo, origin: Square, target: Square) -> bool {
+        debug_assert_ne!(Bitboard::EMPTY, attacks_to_king.attack_origins);
+        let pos = attacks_to_king.pos;
+        let target_bb = Bitboard::from_square(target);
+        match target_bb & attacks_to_king.xrays_to_target {
+            Bitboard::EMPTY => true,
+            _ => {
+                let origin_bb = Bitboard::from_square(origin);
+                let occupancy_after_move = pos.occupancy() & !origin_bb | target_bb;
+                let king_in_check_after_move = attacks_to_king.each_slider_attack.iter().any(|x| {
+                    (x.targets() & origin_bb != Bitboard::EMPTY)
+                        && (Self::sliding_piece_targets(x, occupancy_after_move) & target_bb)
+                            != Bitboard::EMPTY
+                });
+                !king_in_check_after_move
+            }
+        }
+    }
+
+    // Castling is illegal while in check
+    fn generate_castles(_move_list: &mut MoveList, _attacks_to_king: &AttacksTo) {}
+    fn generate_white_castles(_move_list: &mut MoveList, _attacks_to_king: &AttacksTo) {}
+    fn generate_black_castles(_move_list: &mut MoveList, _attacks_to_king: &AttacksTo) {}
+}

--- a/movegen/src/move_generator/king_not_xrayed_generator.rs
+++ b/movegen/src/move_generator/king_not_xrayed_generator.rs
@@ -1,0 +1,55 @@
+use crate::move_generator::move_generator_template::MoveGeneratorTemplate;
+
+use crate::attacks_to::AttacksTo;
+use crate::bitboard::Bitboard;
+use crate::square::Square;
+
+// Since the king is not xrayed, legality checks are only done for:
+// - King move targets
+// - Castles
+pub struct KingNotXrayedGenerator;
+
+impl MoveGeneratorTemplate for KingNotXrayedGenerator {
+    fn non_capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        targets & !attacks_to_king.pos.occupancy()
+    }
+
+    fn capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        targets
+            & attacks_to_king
+                .pos
+                .side_occupancy(!attacks_to_king.pos.side_to_move())
+    }
+
+    fn pawn_capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        targets
+            & (attacks_to_king
+                .pos
+                .side_occupancy(!attacks_to_king.pos.side_to_move())
+                | attacks_to_king.pos.en_passant_square())
+    }
+
+    fn is_legal_non_capture(
+        _attacks_to_king: &AttacksTo,
+        _origin: Square,
+        _target: Square,
+    ) -> bool {
+        true
+    }
+
+    fn is_legal_capture(_attacks_to_king: &AttacksTo, _origin: Square, _target: Square) -> bool {
+        true
+    }
+
+    fn is_legal_en_passant_capture(
+        _attacks_to_king: &AttacksTo,
+        _origin: Square,
+        _target: Square,
+    ) -> bool {
+        true
+    }
+
+    fn is_legal_king_move(_attacks_to_king: &AttacksTo, _origin: Square, _target: Square) -> bool {
+        true
+    }
+}

--- a/movegen/src/move_generator/king_xrayed_generator.rs
+++ b/movegen/src/move_generator/king_xrayed_generator.rs
@@ -1,0 +1,114 @@
+use crate::move_generator::move_generator_template::MoveGeneratorTemplate;
+
+use crate::attacks_to::AttacksTo;
+use crate::bitboard::Bitboard;
+use crate::pawn::Pawn;
+use crate::square::Square;
+
+// Legality checks are done for
+// - King move targets
+// - Castles
+// - Other pieces:
+//   Only if the piece is attacked and xrayed (potentially pinned to the king)
+// - En passant:
+//   Only if own or opponent pawn is attacked and xrayed (potentially pinned to the king)
+pub struct KingXrayedGenerator;
+
+impl MoveGeneratorTemplate for KingXrayedGenerator {
+    fn non_capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        targets & !attacks_to_king.pos.occupancy()
+    }
+
+    fn capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        targets
+            & attacks_to_king
+                .pos
+                .side_occupancy(!attacks_to_king.pos.side_to_move())
+    }
+
+    fn pawn_capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard {
+        targets
+            & (attacks_to_king
+                .pos
+                .side_occupancy(!attacks_to_king.pos.side_to_move())
+                | attacks_to_king.pos.en_passant_square())
+    }
+
+    fn is_legal_non_capture(attacks_to_king: &AttacksTo, origin: Square, target: Square) -> bool {
+        debug_assert!(!attacks_to_king.each_xray.is_empty());
+        let pos = attacks_to_king.pos;
+        let origin_bb = Bitboard::from_square(origin);
+        match origin_bb & attacks_to_king.all_attack_targets & attacks_to_king.xrays_to_target {
+            Bitboard::EMPTY => true,
+            _ => {
+                let target_bb = Bitboard::from_square(target);
+                let own_king = Bitboard::from_square(attacks_to_king.target);
+                let occupancy_after_move = pos.occupancy() & !origin_bb | target_bb;
+                let king_in_check_after_move = attacks_to_king
+                    .each_xray
+                    .iter()
+                    .filter(|x| x.targets() & origin_bb != Bitboard::EMPTY)
+                    .map(|x| Self::sliding_piece_targets(x, occupancy_after_move))
+                    .any(|x| x & own_king != Bitboard::EMPTY);
+                !king_in_check_after_move
+            }
+        }
+    }
+
+    fn is_legal_capture(attacks_to_king: &AttacksTo, origin: Square, target: Square) -> bool {
+        debug_assert!(!attacks_to_king.each_xray.is_empty());
+        let pos = attacks_to_king.pos;
+        let origin_bb = Bitboard::from_square(origin);
+        match origin_bb & attacks_to_king.all_attack_targets & attacks_to_king.xrays_to_target {
+            Bitboard::EMPTY => true,
+            _ => {
+                let own_king = Bitboard::from_square(attacks_to_king.target);
+                let occupancy_after_move = pos.occupancy() & !origin_bb;
+                let king_in_check_after_move = attacks_to_king
+                    .each_xray
+                    .iter()
+                    .filter(|x| {
+                        (x.origin() != target) && (x.targets() & origin_bb != Bitboard::EMPTY)
+                    })
+                    .map(|x| Self::sliding_piece_targets(x, occupancy_after_move))
+                    .any(|x| x & own_king != Bitboard::EMPTY);
+                !king_in_check_after_move
+            }
+        }
+    }
+
+    fn is_legal_en_passant_capture(
+        attacks_to_king: &AttacksTo,
+        origin: Square,
+        target: Square,
+    ) -> bool {
+        debug_assert!(!attacks_to_king.each_xray.is_empty());
+        let pos = attacks_to_king.pos;
+        let origin_bb = Bitboard::from_square(origin);
+        let target_bb = Bitboard::from_square(target);
+        let captured_square = Pawn::push_origin(target, pos.side_to_move());
+        let captured_bb = Bitboard::from_square(captured_square);
+        match (origin_bb | captured_bb)
+            & attacks_to_king.all_attack_targets
+            & attacks_to_king.xrays_to_target
+        {
+            Bitboard::EMPTY => true,
+            _ => {
+                let own_king = Bitboard::from_square(attacks_to_king.target);
+                let occupancy_after_move = pos.occupancy() & !origin_bb & !captured_bb | target_bb;
+                let king_in_check_after_move = attacks_to_king
+                    .each_xray
+                    .iter()
+                    .filter(|x| x.targets() & (origin_bb | captured_bb) != Bitboard::EMPTY)
+                    .map(|x| Self::sliding_piece_targets(x, occupancy_after_move))
+                    .any(|x| x & own_king != Bitboard::EMPTY);
+                !king_in_check_after_move
+            }
+        }
+    }
+
+    fn is_legal_king_move(_attacks_to_king: &AttacksTo, _origin: Square, _target: Square) -> bool {
+        debug_assert!(_attacks_to_king.each_slider_attack.is_empty());
+        true
+    }
+}

--- a/movegen/src/move_generator/move_generator_template.rs
+++ b/movegen/src/move_generator/move_generator_template.rs
@@ -1,0 +1,344 @@
+use crate::attacks_to::AttacksTo;
+use crate::bishop::Bishop;
+use crate::bitboard::Bitboard;
+use crate::king::King;
+use crate::knight::Knight;
+use crate::pawn::Pawn;
+use crate::piece;
+use crate::piece_targets::PieceTargets;
+use crate::position::CastlingRights;
+use crate::queen::Queen;
+use crate::r#move::{Move, MoveList, MoveType};
+use crate::rook::Rook;
+use crate::side::Side;
+use crate::square::Square;
+
+// A move generator template that allows implementers to customize their legality checks
+pub trait MoveGeneratorTemplate {
+    fn non_capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard;
+    fn capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard;
+    fn pawn_capture_target_filter(attacks_to_king: &AttacksTo, targets: Bitboard) -> Bitboard;
+
+    fn is_legal_non_capture(attacks_to_king: &AttacksTo, origin: Square, target: Square) -> bool;
+    fn is_legal_capture(attacks_to_king: &AttacksTo, origin: Square, target: Square) -> bool;
+    fn is_legal_en_passant_capture(
+        attacks_to_king: &AttacksTo,
+        origin: Square,
+        target: Square,
+    ) -> bool;
+    fn is_legal_king_move(attacks_to_king: &AttacksTo, origin: Square, target: Square) -> bool;
+
+    fn generate_moves(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        Self::generate_pawn_moves(move_list, attacks_to_king);
+        Self::generate_knight_moves(move_list, attacks_to_king);
+        Self::generate_sliding_piece_moves(
+            move_list,
+            attacks_to_king,
+            piece::Type::Bishop,
+            Bishop::targets,
+        );
+        Self::generate_sliding_piece_moves(
+            move_list,
+            attacks_to_king,
+            piece::Type::Rook,
+            Rook::targets,
+        );
+        Self::generate_sliding_piece_moves(
+            move_list,
+            attacks_to_king,
+            piece::Type::Queen,
+            Queen::targets,
+        );
+        Self::generate_king_moves(move_list, attacks_to_king);
+        Self::generate_castles(move_list, attacks_to_king);
+    }
+
+    fn generate_king_moves(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        let pos = attacks_to_king.pos;
+        let own_occupancy = pos.side_occupancy(pos.side_to_move());
+        let origin = attacks_to_king.target;
+        let targets = King::targets(origin) & !own_occupancy & !attacks_to_king.all_attack_targets;
+
+        let opponents = pos.side_occupancy(!pos.side_to_move());
+        let mut captures = targets & opponents;
+        let mut quiets = targets & !captures;
+
+        while captures != Bitboard::EMPTY {
+            let target = captures.square_scan_forward_reset();
+            if Self::is_legal_king_move(attacks_to_king, origin, target) {
+                move_list.push(Move::new(origin, target, MoveType::CAPTURE));
+            }
+        }
+        while quiets != Bitboard::EMPTY {
+            let target = quiets.square_scan_forward_reset();
+            if Self::is_legal_king_move(attacks_to_king, origin, target) {
+                move_list.push(Move::new(origin, target, MoveType::QUIET));
+            }
+        }
+    }
+
+    fn generate_knight_moves(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        let pos = attacks_to_king.pos;
+        let mut knights = pos.piece_occupancy(pos.side_to_move(), piece::Type::Knight);
+        let own_occupancy = pos.side_occupancy(pos.side_to_move());
+        while knights != Bitboard::EMPTY {
+            let origin = knights.square_scan_forward_reset();
+            let targets = Knight::targets(origin) & !own_occupancy;
+            Self::generate_piece_moves(move_list, attacks_to_king, origin, targets);
+        }
+    }
+
+    fn generate_sliding_piece_moves(
+        move_list: &mut MoveList,
+        attacks_to_king: &AttacksTo,
+        piece_type: piece::Type,
+        piece_targets: fn(Square, Bitboard) -> Bitboard,
+    ) {
+        let pos = attacks_to_king.pos;
+        let mut piece_occupancy = pos.piece_occupancy(pos.side_to_move(), piece_type);
+        let own_occupancy = pos.side_occupancy(pos.side_to_move());
+        while piece_occupancy != Bitboard::EMPTY {
+            let origin = piece_occupancy.square_scan_forward_reset();
+            let targets = piece_targets(origin, pos.occupancy()) & !own_occupancy;
+            Self::generate_piece_moves(move_list, attacks_to_king, origin, targets);
+        }
+    }
+
+    fn generate_piece_moves(
+        move_list: &mut MoveList,
+        attacks_to_king: &AttacksTo,
+        origin: Square,
+        targets: Bitboard,
+    ) {
+        let mut captures = Self::capture_target_filter(attacks_to_king, targets);
+        let mut quiets = Self::non_capture_target_filter(attacks_to_king, targets);
+
+        while captures != Bitboard::EMPTY {
+            let target = captures.square_scan_forward_reset();
+            if Self::is_legal_capture(attacks_to_king, origin, target) {
+                let m = Move::new(origin, target, MoveType::CAPTURE);
+                move_list.push(m);
+            }
+        }
+        while quiets != Bitboard::EMPTY {
+            let target = quiets.square_scan_forward_reset();
+            if Self::is_legal_non_capture(attacks_to_king, origin, target) {
+                let m = Move::new(origin, target, MoveType::QUIET);
+                move_list.push(m);
+            }
+        }
+    }
+
+    fn generate_pawn_moves(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        Self::generate_pawn_pushes(move_list, attacks_to_king);
+        Self::generate_pawn_captures(move_list, attacks_to_king);
+    }
+
+    fn generate_pawn_pushes(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        let pos = attacks_to_king.pos;
+        let side_to_move = pos.side_to_move();
+        let own_pawns = pos.piece_occupancy(pos.side_to_move(), piece::Type::Pawn);
+
+        let (single_push_targets, double_push_targets) =
+            Pawn::push_targets(own_pawns, pos.occupancy(), side_to_move);
+
+        let single_push_targets =
+            Self::non_capture_target_filter(attacks_to_king, single_push_targets);
+        let mut double_push_targets =
+            Self::non_capture_target_filter(attacks_to_king, double_push_targets);
+        let mut promo_targets = single_push_targets & Pawn::promotion_rank(side_to_move);
+        let mut non_promo_targets = single_push_targets & !promo_targets;
+
+        while promo_targets != Bitboard::EMPTY {
+            let target = promo_targets.square_scan_forward_reset();
+            let origin = Pawn::push_origin(target, side_to_move);
+            if Self::is_legal_non_capture(attacks_to_king, origin, target) {
+                for promo_piece in &[
+                    piece::Type::Queen,
+                    piece::Type::Rook,
+                    piece::Type::Bishop,
+                    piece::Type::Knight,
+                ] {
+                    let m = Move::new(
+                        origin,
+                        target,
+                        MoveType::new_with_promo_piece(MoveType::PROMOTION, *promo_piece),
+                    );
+                    move_list.push(m);
+                }
+            }
+        }
+        while non_promo_targets != Bitboard::EMPTY {
+            let target = non_promo_targets.square_scan_forward_reset();
+            let origin = Pawn::push_origin(target, side_to_move);
+            if Self::is_legal_non_capture(attacks_to_king, origin, target) {
+                let m = Move::new(origin, target, MoveType::QUIET);
+                move_list.push(m);
+            }
+        }
+        while double_push_targets != Bitboard::EMPTY {
+            let target = double_push_targets.square_scan_forward_reset();
+            let origin = Pawn::double_push_origin(target, side_to_move);
+            if Self::is_legal_non_capture(attacks_to_king, origin, target) {
+                let m = Move::new(origin, target, MoveType::DOUBLE_PAWN_PUSH);
+                move_list.push(m);
+            }
+        }
+    }
+
+    fn generate_pawn_captures(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        Self::generate_pawn_captures_one_side(
+            move_list,
+            attacks_to_king,
+            Pawn::east_attack_targets,
+            Pawn::east_attack_origin,
+        );
+
+        Self::generate_pawn_captures_one_side(
+            move_list,
+            attacks_to_king,
+            Pawn::west_attack_targets,
+            Pawn::west_attack_origin,
+        );
+    }
+
+    fn generate_pawn_captures_one_side(
+        move_list: &mut MoveList,
+        attacks_to_king: &AttacksTo,
+        attacks: fn(Bitboard, Side) -> Bitboard,
+        attack_origin: fn(Square, Side) -> Square,
+    ) {
+        let pos = attacks_to_king.pos;
+        let side_to_move = pos.side_to_move();
+        let own_pawns = pos.piece_occupancy(side_to_move, piece::Type::Pawn);
+        let en_passant_square = pos.en_passant_square();
+        let promo_rank = Pawn::promotion_rank(side_to_move);
+        let targets = attacks(own_pawns, side_to_move);
+        let captures = Self::pawn_capture_target_filter(attacks_to_king, targets);
+
+        let mut promo_captures = captures & promo_rank;
+        let mut non_promo_captures = captures & !promo_captures;
+
+        while promo_captures != Bitboard::EMPTY {
+            let target = promo_captures.square_scan_forward_reset();
+            let origin = attack_origin(target, side_to_move);
+            if Self::is_legal_capture(attacks_to_king, origin, target) {
+                for promo_piece in &[
+                    piece::Type::Queen,
+                    piece::Type::Rook,
+                    piece::Type::Bishop,
+                    piece::Type::Knight,
+                ] {
+                    let m = Move::new(
+                        origin,
+                        target,
+                        MoveType::new_with_promo_piece(MoveType::PROMOTION_CAPTURE, *promo_piece),
+                    );
+                    move_list.push(m);
+                }
+            }
+        }
+
+        while non_promo_captures != Bitboard::EMPTY {
+            let target = non_promo_captures.square_scan_forward_reset();
+            let origin = attack_origin(target, side_to_move);
+            if Bitboard::from_square(target) == en_passant_square {
+                if Self::is_legal_en_passant_capture(attacks_to_king, origin, target) {
+                    let m = Move::new(origin, target, MoveType::EN_PASSANT_CAPTURE);
+                    move_list.push(m);
+                }
+            } else if Self::is_legal_capture(attacks_to_king, origin, target) {
+                let m = Move::new(origin, target, MoveType::CAPTURE);
+                move_list.push(m);
+            };
+        }
+    }
+
+    fn sliding_piece_targets(xray: &PieceTargets, occupancy: Bitboard) -> Bitboard {
+        match xray.piece().piece_type() {
+            piece::Type::Bishop => Bishop::targets(xray.origin(), occupancy),
+            piece::Type::Rook => Rook::targets(xray.origin(), occupancy),
+            piece::Type::Queen => Queen::targets(xray.origin(), occupancy),
+            _ => panic!(
+                "Expected sliding piece, found `{:?}` (in `{:?}`)",
+                xray.piece().piece_type(),
+                xray
+            ),
+        }
+    }
+
+    fn generate_castles(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        match attacks_to_king.pos.side_to_move() {
+            Side::White => Self::generate_white_castles(move_list, attacks_to_king),
+            Side::Black => Self::generate_black_castles(move_list, attacks_to_king),
+        }
+    }
+
+    fn generate_white_castles(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        let pos = attacks_to_king.pos;
+        let castling_rights = pos.castling_rights();
+
+        if castling_rights.contains(CastlingRights::WHITE_KINGSIDE) {
+            debug_assert_eq!(Some(piece::Piece::WHITE_KING), pos.piece_at(Square::E1));
+            debug_assert_eq!(Some(piece::Piece::WHITE_ROOK), pos.piece_at(Square::H1));
+            let squares_passable =
+                pos.occupancy() & (Bitboard::F1 | Bitboard::G1) == Bitboard::EMPTY;
+            let squares_attacked = attacks_to_king.all_attack_targets
+                & (Bitboard::E1 | Bitboard::F1 | Bitboard::G1)
+                != Bitboard::EMPTY;
+            if squares_passable && !squares_attacked {
+                move_list.push(Move::new(Square::E1, Square::G1, MoveType::CASTLE_KINGSIDE));
+            }
+        }
+        if castling_rights.contains(CastlingRights::WHITE_QUEENSIDE) {
+            debug_assert_eq!(Some(piece::Piece::WHITE_KING), pos.piece_at(Square::E1));
+            debug_assert_eq!(Some(piece::Piece::WHITE_ROOK), pos.piece_at(Square::A1));
+            let squares_passable =
+                pos.occupancy() & (Bitboard::B1 | Bitboard::C1 | Bitboard::D1) == Bitboard::EMPTY;
+            let squares_attacked = attacks_to_king.all_attack_targets
+                & (Bitboard::C1 | Bitboard::D1 | Bitboard::E1)
+                != Bitboard::EMPTY;
+            if squares_passable && !squares_attacked {
+                move_list.push(Move::new(
+                    Square::E1,
+                    Square::C1,
+                    MoveType::CASTLE_QUEENSIDE,
+                ));
+            }
+        }
+    }
+
+    fn generate_black_castles(move_list: &mut MoveList, attacks_to_king: &AttacksTo) {
+        let pos = attacks_to_king.pos;
+        let castling_rights = pos.castling_rights();
+
+        if castling_rights.contains(CastlingRights::BLACK_KINGSIDE) {
+            debug_assert_eq!(Some(piece::Piece::BLACK_KING), pos.piece_at(Square::E8));
+            debug_assert_eq!(Some(piece::Piece::BLACK_ROOK), pos.piece_at(Square::H8));
+            let squares_passable =
+                pos.occupancy() & (Bitboard::F8 | Bitboard::G8) == Bitboard::EMPTY;
+            let squares_attacked = attacks_to_king.all_attack_targets
+                & (Bitboard::E8 | Bitboard::F8 | Bitboard::G8)
+                != Bitboard::EMPTY;
+            if squares_passable && !squares_attacked {
+                move_list.push(Move::new(Square::E8, Square::G8, MoveType::CASTLE_KINGSIDE));
+            }
+        }
+        if castling_rights.contains(CastlingRights::BLACK_QUEENSIDE) {
+            debug_assert_eq!(Some(piece::Piece::BLACK_KING), pos.piece_at(Square::E8));
+            debug_assert_eq!(Some(piece::Piece::BLACK_ROOK), pos.piece_at(Square::A8));
+            let squares_passable =
+                pos.occupancy() & (Bitboard::B8 | Bitboard::C8 | Bitboard::D8) == Bitboard::EMPTY;
+            let squares_attacked = attacks_to_king.all_attack_targets
+                & (Bitboard::C8 | Bitboard::D8 | Bitboard::E8)
+                != Bitboard::EMPTY;
+            if squares_passable && !squares_attacked {
+                move_list.push(Move::new(
+                    Square::E8,
+                    Square::C8,
+                    MoveType::CASTLE_QUEENSIDE,
+                ));
+            }
+        }
+    }
+}

--- a/movegen/src/piece_targets.rs
+++ b/movegen/src/piece_targets.rs
@@ -1,0 +1,32 @@
+use crate::bitboard::Bitboard;
+use crate::piece::Piece;
+use crate::square::Square;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct PieceTargets {
+    piece: Piece,
+    origin: Square,
+    targets: Bitboard,
+}
+
+impl PieceTargets {
+    pub fn new(piece: Piece, origin: Square, targets: Bitboard) -> PieceTargets {
+        PieceTargets {
+            piece,
+            origin,
+            targets,
+        }
+    }
+
+    pub fn piece(&self) -> Piece {
+        self.piece
+    }
+
+    pub fn origin(&self) -> Square {
+        self.origin
+    }
+
+    pub fn targets(&self) -> Bitboard {
+        self.targets
+    }
+}

--- a/movegen/src/position.rs
+++ b/movegen/src/position.rs
@@ -248,7 +248,7 @@ impl Position {
     fn piece_attacks(
         &self,
         piece_type: piece::Type,
-        piece_targets: &dyn Fn(Square) -> Bitboard,
+        piece_targets: &impl Fn(Square) -> Bitboard,
         side: Side,
     ) -> Bitboard {
         let mut pieces = self.piece_occupancy(side, piece_type);


### PR DESCRIPTION
- Add trait MoveGeneratorTemplate which allows specializing legality
  checks
- Implement specialized move generators for the following cases
  - King in check
  - King xrayed by the opponents' sliders
  - King not xrayed
- Add PieceTargets to store a piece's origin square and its targets
- Add AttacksTo to store information about attacks and xrays to a
  specific square